### PR TITLE
Fix postgresql default type generation

### DIFF
--- a/element/column.go
+++ b/element/column.go
@@ -149,7 +149,7 @@ func (c Column) definition() string {
 		}
 
 		if sql.IsPostgres() && opt.Tp == ast.ColumnOptionDefaultValue {
-			strSql += " " + b.String()
+			strSql += " " + opt.StrValue
 			continue
 		}
 


### PR DESCRIPTION
Right now generation of default values doesn't work properly with Postgresql dialect.
```go
type Model struct {
	ID        string          `sql:"primary_key"`
	CreatedAt time.Time `sql:"type:TIMESTAMP;default:now()"`
	UpdatedAt time.Time `sql:"type:TIMESTAMP;default:now()"`
}
```

This mr would fix it.